### PR TITLE
FIX: removing investigation ordered for participants

### DIFF
--- a/potlako/notebooks/remove_investigation_ordered.ipynb
+++ b/potlako/notebooks/remove_investigation_ordered.ipynb
@@ -1,0 +1,387 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  * Reading config from potlako.ini\n",
+      "Loading Data Encryption (init)...\n",
+      " * loading keys from /Users/samuelkabelo/source/potlako_repos/potlako/crypto_fields\n",
+      " * loading rsa.restricted.public ... Done.\n",
+      " * loading rsa.restricted.private ... Done.\n",
+      " * loading rsa.local.public ... Done.\n",
+      " * loading rsa.local.private ... Done.\n",
+      " * loading aes.local ... Done.\n",
+      " * loading aes.restricted ... Done.\n",
+      " * loading salt.local ... Done.\n",
+      " * loading salt.restricted ... Done.\n",
+      " Done loading Data Encryption (init)...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/samuelkabelo/.venvs/potlako/lib/python3.11/site-packages/django_q/conf.py:139: UserWarning: Retry and timeout are misconfigured. Set retry larger than timeout, \n",
+      "        failure to do so will cause the tasks to be retriggered before completion. \n",
+      "        See https://django-q.readthedocs.io/en/latest/configure.html#retry for details.\n",
+      "  warn(\n",
+      "/Users/samuelkabelo/.venvs/potlako/lib/python3.11/site-packages/simple_history/models.py:164: UserWarning: HistoricalRecords added to abstract model (HistoryManagerMixin) without inherit=True\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/Users/samuelkabelo/.venvs/potlako/lib/python3.11/site-packages/simple_history/models.py:164: UserWarning: HistoricalRecords added to abstract model (ScheduleModelMixin) without inherit=True\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/Users/samuelkabelo/.venvs/potlako/lib/python3.11/site-packages/simple_history/models.py:164: UserWarning: HistoricalRecords added to abstract model (VisitModelMixin) without inherit=True\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/Users/samuelkabelo/.venvs/potlako/lib/python3.11/site-packages/simple_history/models.py:164: UserWarning: HistoricalRecords added to abstract model (CrfModelMixin) without inherit=True\n",
+      "  warnings.warn(msg, UserWarning)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading Data Encryption ...\n",
+      " * found encryption keys in /Users/samuelkabelo/source/potlako_repos/potlako/crypto_fields.\n",
+      " * using model django_crypto_fields.crypt.\n",
+      " Done loading Data Encryption.\n",
+      "Revision: 0.2.23-16-gcbd52c6:bug#7375:cbd52c626a6aa1ba9fc347cab44782c4dadcc261\n",
+      "Loading EDC Call Manager ...\n",
+      " * call models are in app edc_call_manager.\n",
+      " * checking for site model_callers ...\n",
+      " * registered model caller '<class 'potlako_follow.model_callers.model_callers.WorkListFollowUpModelCaller'>'\n",
+      " * registered model caller '<class 'potlako_follow.model_callers.model_callers.NavigationWorkListFollowUpModelCaller'>'\n",
+      " Done loading EDC Call Manager.\n",
+      "Loading Edc Consent ...\n",
+      " * checking for site consents ...\n",
+      " * registered consents 'consents' from 'potlako_subject'\n",
+      " * potlako_subject.subjectconsent 1 covering 2020-03-01 UTC to 2025-12-01 UTC\n",
+      " Done loading Edc Consent.\n",
+      " * checking for site prn_forms ...\n",
+      "Loading Edc Device ...                        \n",
+      "  * device id is '99'.\n",
+      "  * device role is 'CentralServer'.\n",
+      " Done loading Edc Device.\n",
+      "Loading Edc Lab ...\n",
+      " * checking for labs ...\n",
+      " Done loading Edc Lab.\n",
+      "Loading Edc Reference ...\n",
+      " * checking for reference_model_configs ...\n",
+      " * checking for labs ...\n",
+      " * registered reference model configs from application 'potlako_reference'\n",
+      " Done loading Edc Reference.\n",
+      "Loading edc_metadata_rules ...\n",
+      " * checking for metadata_rules ...\n",
+      "   - imported metadata rules from 'potlako_metadata_rules.metadata_rules'\n",
+      " Done loading edc_metadata_rules.\n",
+      "Loading Edc Navbar ...\n",
+      " * checking for site navbars ...\n",
+      " * searching edc_consent                    \r"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/samuelkabelo/.venvs/potlako/lib/python3.11/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.\n",
+      "  warnings.warn(\"Setuptools is replacing distutils.\")\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " * registered navbars 'navbars' from 'edc_consent'\n",
+      " * registered navbars 'navbars' from 'edc_device'\n",
+      " * registered navbars 'navbars' from 'edc_reference'\n",
+      " * registered navbars 'navbars' from 'edc_navbar'\n",
+      " * registered navbars 'navbars' from 'edc_label'\n",
+      " * registered navbars 'navbars' from 'edc_visit_schedule'\n",
+      " * registered navbars 'navbars' from 'edc_calendar'\n",
+      " * registered navbars 'navbars' from 'potlako_dashboard'\n",
+      " * registered navbars 'navbars' from 'potlako_follow'\n",
+      " * registered navbars 'navbars' from 'potlako_reports'\n",
+      " * registered navbars 'navbars' from 'edc_data_manager'\n",
+      " * registered navbars 'navbars' from 'edc_base'\n",
+      " * registered navbars 'navbars' from 'edc_protocol'\n",
+      " * registered navbars 'navbars' from 'edc_sync'\n",
+      " * registered navbars 'navbars' from 'edc_sms'\n",
+      " * registered navbars 'navbars' from 'potlako'\n",
+      " Done loading Edc Navbar.       \n",
+      "Loading Edc Label ...\n",
+      " Label template folder is /Users/samuelkabelo/source/potlako_repos/potlako/label_templates.\n",
+      "Label template folder does not exist!\n",
+      "Not loading label templates\n",
+      " Done loading Edc Label.\n",
+      "Loading Edc Registration ...\n",
+      "  * using edc_registration.registeredsubject\n",
+      " Done loading Edc Registration.\n",
+      "Loading Visit Schedules ...\n",
+      " * checking site for module 'visit_schedules' ...\n",
+      " * registered visit schedule from 'potlako_visit_schedule'\n",
+      " Done loading Visit Schedules.\n",
+      "Loading Edc Timepoint ...\n",
+      " * 'edc_appointment.appointment' is a timepoint model.\n",
+      " * 'edc_appointment.historicalappointment' is a timepoint model.\n",
+      " Done loading Edc Timepoint.\n",
+      "Loading Edc Appointments ...\n",
+      " * edc_appointment.appointment.\n",
+      " Done loading Edc Appointments.\n",
+      "Loading Edc Metadata ...\n",
+      " * using default metadata models from 'edc_metadata'\n",
+      " Done loading Edc Metadata.\n",
+      "Loading Edc Base ...\n",
+      " * default TIME_ZONE Africa/Gaborone.\n",
+      " Done loading Edc Base.\n",
+      "Loading Edc Protocol ...\n",
+      " * BHP132: Potlako Plus.\n",
+      " * Study opening date: 2020-03-01 UTC\n",
+      " * Expected study closing date: 2025-12-01 UTC\n",
+      " Done loading Edc Protocol.\n",
+      "Loading Edc Visit Tracking ...\n",
+      " * potlako_subject.subjectvisit uses model attr 'subject_visit'\n",
+      " Done loading Edc Visit Tracking.\n",
+      "Loading Data Synchronization ...\n",
+      " * checking for models to register ...\n",
+      " * registered models from 'edc_call_manager'.\n",
+      " * registered models from 'edc_lab'.\n",
+      " * registered models from 'edc_locator'.\n",
+      " * registered models from 'edc_reference'.\n",
+      " * registered models from 'edc_registration'.\n",
+      " * registered models from 'edc_visit_schedule'.\n",
+      " * registered models from 'potlako_follow'.\n",
+      " * registered models from 'potlako_prn'.\n",
+      " * registered models from 'potlako_subject'.\n",
+      " * registered models from 'edc_appointment'.\n",
+      " * registered models from 'edc_metadata'.\n",
+      " * registered models from 'edc_identifier'.\n",
+      " Done loading Data Synchronization.\n",
+      "Loading File support for data synchronization ...\n",
+      "Done loading File support for data synchronization.\n",
+      "Loading Edc Facility ...\n",
+      " * 7-Day Clinic MO(100 slots), TU(100 slots), WE(100 slots), TH(100 slots), FR(100 slots), SA(100 slots), SU(100 slots).\n",
+      " * 5-Day Clinic MO(100 slots), TU(100 slots), WE(100 slots), TH(100 slots), FR(100 slots).\n",
+      " Done loading Edc Facility.\n",
+      "Loading Edc Identifier ...\n",
+      " * identifier prefix: 132\n",
+      " * check-digit modulus: 7\n",
+      " Done loading Edc Identifier\n"
+     ]
+    }
+   ],
+   "source": [
+    "import os, sys\n",
+    "import django\n",
+    "\n",
+    "sys.path.append('../..') # add path to project root dir\n",
+    "os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'potlako.settings')\n",
+    "os.environ[\"DJANGO_ALLOW_ASYNC_UNSAFE\"] = \"true\"\n",
+    "\n",
+    "# for more sophisticated setups, if you need to change connection settings (e.g. when using django-environ):\n",
+    "#os.environ[\"DATABASE_URL\"] = \"postgres://myuser:mypassword@localhost:54324/mydb\"\n",
+    "\n",
+    "# Connect to Django ORM\n",
+    "django.setup()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "\"\"\"Remove Investigation Ordered Form not required\"\"\"\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from potlako_subject.models import (PatientCallFollowUp,\n",
+    "                                    InvestigationsOrdered,\n",
+    "                                    InvestigationsResulted,\n",
+    "                                    SubjectVisit,\n",
+    "                                    LabTest)\n",
+    "from edc_appointment.models import Appointment\n",
+    "from edc_metadata.models import CrfMetadata\n",
+    "from edc_metadata.constants import KEYED\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# check the patientfollow-up\n",
+    "# check if appointment is done\n",
+    "\n",
+    "def investigations_ordered_remove(subject_identifier, visit_code, seq):\n",
+    "    \"\"\"\n",
+    "    - This function checks a patients appointment then using the subject visit the patient\n",
+    "    follow-up update the investigations_ordered\n",
+    "    - Delete investigation results and lab test if the investigation_ordered is captured\n",
+    "\n",
+    "    Parameters: SubjectIdentifier, visitCode, sequence used to get the appointment,  \"\"\"\n",
+    "    try:\n",
+    "        appointment = Appointment.objects.get(\n",
+    "            subject_identifier=subject_identifier,\n",
+    "            visit_code=visit_code,\n",
+    "            visit_code_sequence=seq)\n",
+    "\n",
+    "    except Appointment.DoesNotExist as e:\n",
+    "        print(f'Appointment does not exist: {e}')\n",
+    "    else:\n",
+    "        if appointment.appt_status == 'done':\n",
+    "\n",
+    "            # get the follow-up object\n",
+    "            sv = SubjectVisit.objects.get(appointment=appointment)\n",
+    "            fu = PatientCallFollowUp.objects.get(subject_visit_id=sv.id)\n",
+    "\n",
+    "            # check crf metadata\n",
+    "            crf_metadata = CrfMetadata.objects.get(\n",
+    "                subject_identifier=subject_identifier,\n",
+    "                visit_code=visit_code,\n",
+    "                visit_code_sequence=seq,\n",
+    "                entry_status=KEYED,\n",
+    "                model='potlako_subject.investigationsordered')\n",
+    "\n",
+    "\n",
+    "            if crf_metadata:\n",
+    "\n",
+    "                fu.investigations_ordered = 'No'\n",
+    "                fu.save()\n",
+    "\n",
+    "\n",
+    "                # delete results, lab tests\n",
+    "                investigation_ordered = InvestigationsOrdered.objects.get(subject_visit_id=sv.id)\n",
+    "                if investigation_ordered:\n",
+    "                    delete_lab_tests_exists(investigation_ordered)\n",
+    "                    delete_investigation_results_exists(sv.id)\n",
+    "            else:\n",
+    "                print(\"CRF Metadata not found\")\n",
+    "        else:\n",
+    "            print(\"Appointment not yet done\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def delete_lab_tests_exists(investigation) -> None:\n",
+    "\n",
+    "    \"\"\"Deletes LabTests if exists\"\"\"\n",
+    "    LabTest.objects.filter(investigations=investigation).delete()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def delete_investigation_results_exists(subject_visit_id) -> None:\n",
+    "\n",
+    "    \"\"\"Deletes Investigation Results if exists \"\"\"\n",
+    "    try:\n",
+    "        InvestigationsResulted.objects.get(subject_visit_id=subject_visit_id).delete()\n",
+    "    except InvestigationsResulted.DoesNotExist:\n",
+    "        pass\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Watson\n",
+      "Watson be patient almost there\n",
+      "Watson lets work almost there\n"
+     ]
+    }
+   ],
+   "source": [
+    "investigations_ordered_remove(subject_identifier='132-40990109-8',visit_code=1000, seq=1)\n",
+    "investigations_ordered_remove(subject_identifier='132-40990155-1',visit_code=1000, seq=1)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check metadata\n",
+    "try:\n",
+    "    crf_count = CrfMetadata.objects.filter(\n",
+    "    subject_identifier='132-40990155-1',\n",
+    "    visit_code=1000,\n",
+    "    visit_code_sequence=1,\n",
+    "    entry_status=KEYED).count()\n",
+    "    assert crf_count == 1\n",
+    "\n",
+    "except AssertionError as msg:\n",
+    "    print(msg)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}


### PR DESCRIPTION
- Created a function that checks an appointment status then using the subject visit gets the patient follow-up update then updates the investigations_ordered field.
- Delete investigation results and lab test if the investigation ordered object exists