### PR TITLE
Add new Jupyter notebook for navigation action items


### DIFF
--- a/potlako/notebooks/create_nav_action_iterms.ipynb
+++ b/potlako/notebooks/create_nav_action_iterms.ipynb
@@ -1,0 +1,285 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "id": "initial_id",
+   "metadata": {
+    "collapsed": true,
+    "ExecuteTime": {
+     "end_time": "2024-07-02T12:53:16.718219Z",
+     "start_time": "2024-07-02T12:53:09.130987Z"
+    }
+   },
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "\n",
+    "import django\n",
+    "\n",
+    "sys.path.append('../..')  # add path to project root dir\n",
+    "os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'potlako.settings')\n",
+    "os.environ[\"DJANGO_ALLOW_ASYNC_UNSAFE\"] = \"true\"\n",
+    "\n",
+    "# for more sophisticated setups, if you need to change connection settings (e.g. when using django-environ):\n",
+    "#os.environ[\"DATABASE_URL\"] = \"postgres://myuser:mypassword@localhost:54324/mydb\"\n",
+    "\n",
+    "# Connect to Django ORM\n",
+    "django.setup()"
+   ],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  * Reading config from potlako.ini\n",
+      "Loading Data Encryption (init)...\n",
+      " * loading keys from /Users/nimrodmunatsi/source/potlako-code-space/potlako/crypto_fields\n",
+      " * loading rsa.restricted.public ... Done.\n",
+      " * loading rsa.restricted.private ... Done.\n",
+      " * loading rsa.local.public ... Done.\n",
+      " * loading rsa.local.private ... Done.\n",
+      " * loading aes.local ... Done.\n",
+      " * loading aes.restricted ... Done.\n",
+      " * loading salt.local ... Done.\n",
+      " * loading salt.restricted ... Done.\n",
+      " Done loading Data Encryption (init)...\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nimrodmunatsi/.venv/potlako/lib/python3.9/site-packages/django_q/conf.py:139: UserWarning: Retry and timeout are misconfigured. Set retry larger than timeout, \n",
+      "        failure to do so will cause the tasks to be retriggered before completion. \n",
+      "        See https://django-q.readthedocs.io/en/latest/configure.html#retry for details.\n",
+      "  warn(\n",
+      "/Users/nimrodmunatsi/.venv/potlako/lib/python3.9/site-packages/simple_history/models.py:164: UserWarning: HistoricalRecords added to abstract model (HistoryManagerMixin) without inherit=True\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/Users/nimrodmunatsi/.venv/potlako/lib/python3.9/site-packages/simple_history/models.py:164: UserWarning: HistoricalRecords added to abstract model (ScheduleModelMixin) without inherit=True\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/Users/nimrodmunatsi/.venv/potlako/lib/python3.9/site-packages/simple_history/models.py:164: UserWarning: HistoricalRecords added to abstract model (VisitModelMixin) without inherit=True\n",
+      "  warnings.warn(msg, UserWarning)\n",
+      "/Users/nimrodmunatsi/.venv/potlako/lib/python3.9/site-packages/simple_history/models.py:164: UserWarning: HistoricalRecords added to abstract model (CrfModelMixin) without inherit=True\n",
+      "  warnings.warn(msg, UserWarning)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loading Data Encryption ...\n",
+      " * found encryption keys in /Users/nimrodmunatsi/source/potlako-code-space/potlako/crypto_fields.\n",
+      " * using model django_crypto_fields.crypt.\n",
+      " Done loading Data Encryption.\n",
+      "Revision: 0.2.23-93-gf96d40f:develop:f96d40fa60b8612d8589e63de30ad7888857b93a\n",
+      "Loading EDC Call Manager ...\n",
+      " * call models are in app edc_call_manager.\n",
+      " * checking for site model_callers ...\n",
+      " * registered model caller '<class 'potlako_follow.model_callers.model_callers.WorkListFollowUpModelCaller'>'\n",
+      " * registered model caller '<class 'potlako_follow.model_callers.model_callers.NavigationWorkListFollowUpModelCaller'>'\n",
+      " Done loading EDC Call Manager.\n",
+      "Loading Edc Consent ...\n",
+      " * checking for site consents ...\n",
+      " * registered consents 'consents' from 'potlako_subject'\n",
+      " * potlako_subject.subjectconsent 1 covering 2020-03-01 UTC to 2025-12-01 UTC\n",
+      " Done loading Edc Consent.\n",
+      " * checking for site prn_forms ...\n",
+      "Loading Edc Device ...                        \n",
+      "  * device id is '40'.\n",
+      "  * device role is 'Client'.\n",
+      " Done loading Edc Device.\n",
+      "Loading Edc Lab ...\n",
+      " * checking for labs ...\n",
+      " Done loading Edc Lab.\n",
+      "Loading Edc Reference ...\n",
+      " * checking for reference_model_configs ...\n",
+      " * checking for labs ...\n",
+      " * registered reference model configs from application 'potlako_reference'\n",
+      " Done loading Edc Reference.\n",
+      "Loading edc_metadata_rules ...\n",
+      " * checking for metadata_rules ...\n",
+      "   - imported metadata rules from 'potlako_metadata_rules.metadata_rules'\n",
+      " Done loading edc_metadata_rules.\n",
+      "Loading Edc Navbar ...\n",
+      " * checking for site navbars ...\n",
+      " * searching edc_consent           \r        "
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/Users/nimrodmunatsi/.venv/potlako/lib/python3.9/site-packages/_distutils_hack/__init__.py:33: UserWarning: Setuptools is replacing distutils.\n",
+      "  warnings.warn(\"Setuptools is replacing distutils.\")\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      " * registered navbars 'navbars' from 'edc_consent'\n",
+      " * registered navbars 'navbars' from 'edc_device'\n",
+      " * registered navbars 'navbars' from 'edc_reference'\n",
+      " * registered navbars 'navbars' from 'edc_navbar'\n",
+      " * registered navbars 'navbars' from 'edc_label'\n",
+      " * registered navbars 'navbars' from 'edc_visit_schedule'\n",
+      " * registered navbars 'navbars' from 'edc_calendar'\n",
+      " * registered navbars 'navbars' from 'potlako_dashboard'\n",
+      " * registered navbars 'navbars' from 'potlako_follow'\n",
+      " * registered navbars 'navbars' from 'potlako_reports'\n",
+      " * registered navbars 'navbars' from 'edc_data_manager'\n",
+      " * registered navbars 'navbars' from 'edc_base'\n",
+      " * registered navbars 'navbars' from 'edc_protocol'\n",
+      " * registered navbars 'navbars' from 'edc_sync'\n",
+      " * registered navbars 'navbars' from 'edc_sms'\n",
+      " * registered navbars 'navbars' from 'potlako'\n",
+      " Done loading Edc Navbar.       \n",
+      "Loading Edc Label ...\n",
+      " Label template folder is /Users/nimrodmunatsi/source/potlako-code-space/potlako/label_templates.\n",
+      "Label template folder does not exist!\n",
+      "Not loading label templates\n",
+      " Done loading Edc Label.\n",
+      "Loading Edc Registration ...\n",
+      "  * using edc_registration.registeredsubject\n",
+      " Done loading Edc Registration.\n",
+      "Loading Visit Schedules ...\n",
+      " * checking site for module 'visit_schedules' ...\n",
+      " * registered visit schedule from 'potlako_visit_schedule'\n",
+      " Done loading Visit Schedules.\n",
+      "Loading Edc Timepoint ...\n",
+      " * 'edc_appointment.appointment' is a timepoint model.\n",
+      " * 'edc_appointment.historicalappointment' is a timepoint model.\n",
+      " Done loading Edc Timepoint.\n",
+      "Loading Edc Appointments ...\n",
+      " * edc_appointment.appointment.\n",
+      " Done loading Edc Appointments.\n",
+      "Loading Edc Metadata ...\n",
+      " * using default metadata models from 'edc_metadata'\n",
+      " Done loading Edc Metadata.\n",
+      "Loading Edc Base ...\n",
+      " * default TIME_ZONE Africa/Gaborone.\n",
+      " Done loading Edc Base.\n",
+      "Loading Edc Protocol ...\n",
+      " * BHP132: Potlako Plus.\n",
+      " * Study opening date: 2020-03-01 UTC\n",
+      " * Expected study closing date: 2025-12-01 UTC\n",
+      " Done loading Edc Protocol.\n",
+      "Loading Edc Visit Tracking ...\n",
+      " * potlako_subject.subjectvisit uses model attr 'subject_visit'\n",
+      " Done loading Edc Visit Tracking.\n",
+      "Loading Data Synchronization ...\n",
+      " * checking for models to register ...\n",
+      " * registered models from 'edc_call_manager'.\n",
+      " * registered models from 'edc_lab'.\n",
+      " * registered models from 'edc_locator'.\n",
+      " * registered models from 'edc_reference'.\n",
+      " * registered models from 'edc_registration'.\n",
+      " * registered models from 'edc_visit_schedule'.\n",
+      " * registered models from 'potlako_follow'.\n",
+      " * registered models from 'potlako_prn'.\n",
+      " * registered models from 'potlako_subject'.\n",
+      " * registered models from 'edc_appointment'.\n",
+      " * registered models from 'edc_metadata'.\n",
+      " * registered models from 'edc_identifier'.\n",
+      " Done loading Data Synchronization.\n",
+      "Loading File support for data synchronization ...\n",
+      "Done loading File support for data synchronization.\n",
+      "Loading Edc Facility ...\n",
+      " * 7-Day Clinic MO(100 slots), TU(100 slots), WE(100 slots), TH(100 slots), FR(100 slots), SA(100 slots), SU(100 slots).\n",
+      " * 5-Day Clinic MO(100 slots), TU(100 slots), WE(100 slots), TH(100 slots), FR(100 slots).\n",
+      " Done loading Edc Facility.\n",
+      "Loading Edc Identifier ...\n",
+      " * identifier prefix: 132\n",
+      " * check-digit modulus: 7\n",
+      " Done loading Edc Identifier\n"
+     ]
+    }
+   ],
+   "execution_count": 1
+  },
+  {
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2024-07-02T13:05:44.197095Z",
+     "start_time": "2024-07-02T13:05:21.438505Z"
+    }
+   },
+   "cell_type": "code",
+   "source": [
+    "from potlako_subject.action_items import NAVIGATION_PLANS_ACTION\n",
+    "from potlako_subject.models import NavigationSummaryAndPlan\n",
+    "from edc_constants.constants import OPEN\n",
+    "from edc_action_item import site_action_items\n",
+    "from edc_action_item.models import ActionItem\n",
+    "from tqdm import tqdm\n",
+    "\n",
+    "nav_plan_objs = NavigationSummaryAndPlan.objects.all()\n",
+    "for nav_plan_obj in tqdm(nav_plan_objs):\n",
+    "    try:\n",
+    "        action_item_obj = ActionItem.objects.get(\n",
+    "            subject_identifier=nav_plan_obj.subject_identifier,\n",
+    "            action_type__name=NAVIGATION_PLANS_ACTION)\n",
+    "    except ActionItem.DoesNotExist:\n",
+    "        action_cls = site_action_items.get(NAVIGATION_PLANS_ACTION)\n",
+    "        action_cls(subject_identifier=nav_plan_obj.subject_identifier)\n",
+    "    else:\n",
+    "        action_item_obj.status = OPEN\n",
+    "        action_item_obj.save()\n",
+    "    finally:\n",
+    "        try:\n",
+    "            action_item = ActionItem.objects.get(\n",
+    "                subject_identifier=nav_plan_obj.subject_identifier,\n",
+    "                action_type__name=NAVIGATION_PLANS_ACTION)\n",
+    "        except ActionItem.DoesNotExist:\n",
+    "            pass\n",
+    "        except ActionItem.MultipleObjectsReturned:\n",
+    "            print(nav_plan_obj.subject_identifier)\n",
+    "        else:\n",
+    "            nav_plan_obj.action_identifier = action_item.action_identifier\n",
+    "            nav_plan_obj.save()\n",
+    "\n",
+    "\n"
+   ],
+   "id": "bfe2d02a171f59a4",
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "100%|██████████| 492/492 [00:22<00:00, 22.20it/s]\n"
+     ]
+    }
+   ],
+   "execution_count": 4
+  },
+  {
+   "metadata": {},
+   "cell_type": "code",
+   "outputs": [],
+   "execution_count": null,
+   "source": "",
+   "id": "46bd41fc65e5ca05"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION

This new notebook 'create_nav_action_items.ipynb' includes code for creating navigation summary and plans action items, setting their status as 'OPEN', and linking them to their associated navigation plan objects in the potlako project. It handles scenarios where action items do not exist, or multiple instances are returned.